### PR TITLE
記事一覧をRiot.jsで書いた

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -3,25 +3,6 @@ layout: default
 title: 記事一覧
 ---
 <article-paginator></article-paginator>
-<h1><span class="show-only-tag-exists" style="display: none;">タグ '<span class="tag-name"></span>' の</span>記事一覧</h1>
-<div class="articles">
-  {% for post in site.posts %}
-  {% include article.html page=post donotshowall=true %}
-  {% endfor %}
-</div>
-
-<div id="tag-unknown">
-  <span class="tag-name"></span>にマッチする記事はありません。
-</div>
-
-<div class="article-nav">
-  <div id="prev-page" style="float: left; display: none;">
-    <a href="" id="prev-page-link"><i class="fa fa-chevron-left"></i>新しい記事</a>
-  </div>
-  <div id="next-page" style="text-align: right; display: none;">
-    <a href="" id="next-page-link">古い記事<i class="fa fa-chevron-right"></i></a>
-  </div>
-</div>
 
 <script>
  window.GlobalConfig = {

--- a/articles.html
+++ b/articles.html
@@ -35,7 +35,21 @@ title: 記事一覧
 <script type="riot/tag" src="/assets/tag/article-list.tag"></script>
 <script type="riot/tag" src="/assets/tag/article-entry.tag"></script>
 <script>
+ const observable = riot.observable();
  riot.compile(() => {
-   riot.mount('*');
+   riot.mount('*', { observable: observable });
+ });
+
+ if (document.readyState !== 'loading') {
+   observable.trigger('HashChanged');
+ } else {
+   document.addEventListener('DOMContentLoaded', () => {
+     observable.trigger('HashChanged');
+   });
+ }
+
+ window.addEventListener('hashchange', () => {
+   observable.trigger('HashChanged');
+   window.scrollTo(0, 0);
  });
 </script>

--- a/articles.html
+++ b/articles.html
@@ -2,6 +2,7 @@
 layout: default
 title: 記事一覧
 ---
+<article-paginator></article-paginator>
 <h1><span class="show-only-tag-exists" style="display: none;">タグ '<span class="tag-name"></span>' の</span>記事一覧</h1>
 <div class="articles">
   {% for post in site.posts %}
@@ -27,4 +28,14 @@ title: 記事一覧
    offset: {{ site.num_articles_per_page | default: 10 }}
  };
 </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
 <script src="{{ '/assets/js/article-paginator.js' | relative_url }}"></script>
+<script src="https://cdn.jsdelivr.net/npm/riot@3.8.1/riot+compiler.min.js"></script>
+<script type="riot/tag" src="/assets/tag/article-paginator.tag"></script>
+<script type="riot/tag" src="/assets/tag/article-list.tag"></script>
+<script type="riot/tag" src="/assets/tag/article-entry.tag"></script>
+<script>
+ riot.compile(() => {
+   riot.mount('*');
+ });
+</script>

--- a/articles.json
+++ b/articles.json
@@ -13,7 +13,7 @@
   {
     "title": "{{ post.title | url_encode }}",
     "date": "{{ post.date | date: "%Y/%m/%d" }}",
-    "url": "{{ post.url}}",
+    "url": "{{ post.url }}",
     "tags": [
       {% assign first_tag = true %}
       {% for tag in post.tags %}

--- a/assets/tag/article-entry.tag
+++ b/assets/tag/article-entry.tag
@@ -1,0 +1,3 @@
+<article-entry>
+  <h2>{ opts.entry.title }</h2>
+</article-entry>

--- a/assets/tag/article-entry.tag
+++ b/assets/tag/article-entry.tag
@@ -1,3 +1,11 @@
 <article-entry>
-  <h2>{ opts.entry.title }</h2>
+  <article>
+    <h1>
+      <a href={ opts.entry.url}>{ opts.entry.title }</a>
+    </h1>
+    <hr>
+    <div class="article-body">
+      { opts.entry.summary }
+    </div>
+  </article>
 </article-entry>

--- a/assets/tag/article-list.tag
+++ b/assets/tag/article-list.tag
@@ -1,0 +1,46 @@
+<article-list>
+  <h1>{ title }</h1>
+  <article-entry each={ article in targetArticles } entry={ article }>
+  </article-entry>
+  <script>
+   loadArticles() {
+     fetch(opts.source).then((resp) => {
+       return resp.json();
+     }).then((articles) => {
+       this.articles = articles.map((article) => {
+         return {
+           "title": decodeURI(article.title),
+           "date": article.date,
+           "url": article.url,
+           "tags" : article.tags.map((t) => decodeURI(t)),
+           "summary": decodeURI(article.summary)
+         };
+       });
+       this.trigger('articlesLoaded');
+     });
+   }
+
+   makeFilter(args) {
+     return (articles) => articles
+       .filter((a) => args.tag === null ||
+                    a.tags.find((elt) => elt === args.tag))
+       .slice(args.page * args.offset, (args.page + 1) * args.offset);
+   }
+
+   this.filter = this.makeFilter(opts.filters);
+
+   if (this.opts.tag == null) {
+     this.title = '記事一覧';
+   } else {
+     this.title = `タグ「{tag}」の記事一覧`;
+   }
+
+   this.on('articlesLoaded', () => {
+     this.targetArticles = this.filter(this.articles);
+     this.update();
+   });
+
+   this.loadArticles();
+  </script>
+</article-list>
+

--- a/assets/tag/article-list.tag
+++ b/assets/tag/article-list.tag
@@ -2,6 +2,16 @@
   <h1>{ title }</h1>
   <article-entry each={ article in targetArticles } entry={ article }>
   </article-entry>
+
+  <div class="article-nav">
+    <div id="prev-page" style="float: left;" if={ prevPageExists }>
+      <a href={ prevPageUrl } id="prev-page-link"><i class="fa fa-chevron-left"></i>新しい記事</a>
+    </div>
+    <div id="next-page" style="text-align: right;" if={ nextPageExists }>
+      <a href={ nextPageUrl } id="next-page-link">古い記事<i class="fa fa-chevron-right"></i></a>
+    </div>
+  </div>
+
   <script>
    loadArticles() {
      fetch(opts.source).then((resp) => {
@@ -20,20 +30,39 @@
      });
    }
 
-   makeFilter(args) {
-     return (articles) => articles
-       .filter((a) => args.tag === null ||
-                    a.tags.find((elt) => elt === args.tag))
-       .slice(args.page * args.offset, (args.page + 1) * args.offset);
    decode (data) {
      return decodeURIComponent(data.replace('+', ' '));
    }
 
+   showContents() {
+     const articlesOfTag = this.filterTags(this.articles, opts.filters.tag);
+     this.targetArticles = this.paginate(
+       articlesOfTag, opts.filters.page, opts.filters.offset);
+     this.prevPageExists = opts.filters.page > 0;
+     this.nextPageExists =
+       (opts.filters.page + 1) * opts.filters.offset < articlesOfTag.length;
+     this.prevPageUrl = this.urlFor(opts.filters.tag, opts.filters.page - 1);
+     this.nextPageUrl = this.urlFor(opts.filters.tag, opts.filters.page + 1);
    }
 
-   this.filter = this.makeFilter(opts.filters);
+   filterTags(articles, tag) {
+     return articles.filter((a) => tag === null ||
+                                 a.tags.find((elt) => elt === tag));
+   }
+
+   paginate(articles, page, offset) {
+     return articles.slice(page * offset, (page + 1) * offset);
+   }
+
+   urlFor(tag, page) {
+     if (tag) return `#${tag}/${page}`;
+     else return `#${page}`;
+   }
+
    this.articles = [];
    this.targetArticles = [];
+   this.prevPageExists = false;
+   this.nextPageExists = false;
 
    if (this.opts.tag == null) {
      this.title = '記事一覧';
@@ -42,8 +71,12 @@
    }
 
    this.on('articlesLoaded', () => {
-     this.targetArticles = this.filter(this.articles);
+     this.showContents();
      this.update();
+   });
+
+   this.on('update', () => {
+     this.showContents();
    });
 
    this.loadArticles();

--- a/assets/tag/article-list.tag
+++ b/assets/tag/article-list.tag
@@ -9,11 +9,11 @@
      }).then((articles) => {
        this.articles = articles.map((article) => {
          return {
-           "title": decodeURI(article.title),
+           "title": this.decode(article.title),
            "date": article.date,
            "url": article.url,
-           "tags" : article.tags.map((t) => decodeURI(t)),
-           "summary": decodeURI(article.summary)
+           "tags" : article.tags.map((t) => this.decode(t)),
+           "summary": this.decode(article.summary)
          };
        });
        this.trigger('articlesLoaded');
@@ -25,6 +25,10 @@
        .filter((a) => args.tag === null ||
                     a.tags.find((elt) => elt === args.tag))
        .slice(args.page * args.offset, (args.page + 1) * args.offset);
+   decode (data) {
+     return decodeURIComponent(data.replace('+', ' '));
+   }
+
    }
 
    this.filter = this.makeFilter(opts.filters);

--- a/assets/tag/article-list.tag
+++ b/assets/tag/article-list.tag
@@ -28,6 +28,8 @@
    }
 
    this.filter = this.makeFilter(opts.filters);
+   this.articles = [];
+   this.targetArticles = [];
 
    if (this.opts.tag == null) {
      this.title = '記事一覧';

--- a/assets/tag/article-paginator.tag
+++ b/assets/tag/article-paginator.tag
@@ -1,21 +1,7 @@
 <article-paginator>
   <article-list source={ src } filters={ filters }></article-list>
 
-  <div class="article-nav">
-    <div id="prev-page" style="float: left;">
-      <a href="" id="prev-page-link"><i class="fa fa-chevron-left"></i>新しい記事</a>
-    </div>
-    <div id="next-page" style="text-align: right;">
-      <a href="" id="next-page-link">古い記事<i class="fa fa-chevron-right"></i></a>
-    </div>
-  </div>
-
   <script>
-   urlFor(tag, page) {
-     if (tag) return `#${tag}/${page}`;
-     else return `#${page}`;
-   }
-
    route(hash) {
      // #PAGE
      var match = hash.match(/^#(\d+)\/?$/);
@@ -39,9 +25,11 @@
    };
 
    opts.observable.on('HashChanged', () => {
+     filters = this.route(location.hash);
      filters.offset = GlobalConfig.offset;
      this.filters = filters;
      console.log(this.filters);
+     this.update();
    });
   </script>
 </article-paginator>

--- a/assets/tag/article-paginator.tag
+++ b/assets/tag/article-paginator.tag
@@ -18,11 +18,9 @@
    };
 
    this.src = '/articles.json';
-   this.filters = {
-     tag: null,
-     page: 0,
-     offset: GlobalConfig.offset
-   };
+   this.filters = this.route(location.hash);
+   this.filters.offset = GlobalConfig.offset;
+   console.log(this.filters);
 
    opts.observable.on('HashChanged', () => {
      filters = this.route(location.hash);

--- a/assets/tag/article-paginator.tag
+++ b/assets/tag/article-paginator.tag
@@ -1,0 +1,11 @@
+<article-paginator>
+  <article-list source={ src } filters={ filters }></article-list>
+  <script>
+   this.src = '/articles.json';
+   this.filters = {
+     tag: null,
+     page: 0,
+     offset: GlobalConfig.offset
+   };
+  </script>
+</article-paginator>

--- a/assets/tag/article-paginator.tag
+++ b/assets/tag/article-paginator.tag
@@ -1,11 +1,47 @@
 <article-paginator>
   <article-list source={ src } filters={ filters }></article-list>
+
+  <div class="article-nav">
+    <div id="prev-page" style="float: left;">
+      <a href="" id="prev-page-link"><i class="fa fa-chevron-left"></i>新しい記事</a>
+    </div>
+    <div id="next-page" style="text-align: right;">
+      <a href="" id="next-page-link">古い記事<i class="fa fa-chevron-right"></i></a>
+    </div>
+  </div>
+
   <script>
+   urlFor(tag, page) {
+     if (tag) return `#${tag}/${page}`;
+     else return `#${page}`;
+   }
+
+   route(hash) {
+     // #PAGE
+     var match = hash.match(/^#(\d+)\/?$/);
+     if (match) {
+       return { tag: null, page: match[1] ? parseInt(match[1]) : 0 };
+     }
+     // #TAG/PAGE
+     match = hash.match(/^#([^\/]+)(\/(\d*)\/?)?$/);
+     if (match) return {
+       tag: match[1] ? decodeURI(match[1]) : null,
+       page: match[3] ? parseInt(match[3]) : 0
+     };
+     return { tag: null, page: 0 };
+   };
+
    this.src = '/articles.json';
    this.filters = {
      tag: null,
      page: 0,
      offset: GlobalConfig.offset
    };
+
+   opts.observable.on('HashChanged', () => {
+     filters.offset = GlobalConfig.offset;
+     this.filters = filters;
+     console.log(this.filters);
+   });
   </script>
 </article-paginator>


### PR DESCRIPTION
👍 前みたいにDOM死ぬほど弄らなくてもOKなので楽

👎 jekyll側と見た目の共有(絵文字とか)ができなくなってしまった
👎 jekyll+github pagesのデフォルトのプラグインだけでまともなJSON吐くのがだるい
👎 ↑の影響でJSON内の文字列をdecodeURIComponentするみたいな意味不明作業が発生
👎 測ってないけどRiot.jsのコンパイルとかが走るぶんたぶん前より遅い

というわけで作ったはいいもののとりあえず保留